### PR TITLE
[feature] Validation of diagnostics against AMDAR data through CLI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
     types:
+      - opened
+      - synchronize
+      - reopened
       - ready_for_review
   workflow_dispatch:
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+    types:
+      - ready_for_review
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - .github/workflows/release.yml
       - .github/workflows/sphinx.yml
   pull_request:
+    types:
+      - ready_for_review
     branches: [ "master" , "dev" ]
     paths-ignore:
       - .github/workflows/cd.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
       - .github/workflows/sphinx.yml
   pull_request:
     types:
+      - opened
+      - synchronize
+      - reopened
       - ready_for_review
     branches: [ "master" , "dev" ]
     paths-ignore:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,4 +109,5 @@ exclude_also = [
     'if __name__ == .__main__.:',
     'if TYPE_CHECKING:',
     '@(abc\.)?abstractmethod',
+    '^\s*(logger|logging)\.\w+\(.*\)', # ignore logging statements
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,14 @@ packages = ["src/rojak"]
 
 [tool.hatch.version]
 source = "vcs"
+
+[tool.coverage.report]
+exclude_also = [
+    'def __repr__',
+    'raise AssertionError',
+    'raise NotImplementedError',
+    'if 0:',
+    'if __name__ == .__main__.:',
+    'if TYPE_CHECKING:',
+    '@(abc\.)?abstractmethod',
+]

--- a/src/rojak/cli/main.py
+++ b/src/rojak/cli/main.py
@@ -23,7 +23,7 @@ from rich.logging import RichHandler
 
 from rojak.cli import data_interface
 from rojak.orchestrator.configuration import Context as ConfigContext
-from rojak.orchestrator.turbulence import DiagnosticsAmdarLauncher, TurbulenceLauncher
+from rojak.orchestrator.turbulence import TurbulenceLauncher
 
 app = typer.Typer()
 app.add_typer(data_interface.data_app, name="data")
@@ -61,12 +61,7 @@ def run(
     client = Client()
     context = ConfigContext.from_yaml(config_file)
 
-    turbulence_result = None
     if context.turbulence_config is not None:
-        turbulence_result = TurbulenceLauncher(context).launch()
+        TurbulenceLauncher(context).launch()
 
-    if turbulence_result is None and context.data_config.amdar_config is not None:
-        raise ValueError("Failed to launch diagnostic amdar harmonisation as evaluation phase was not run")
-    if turbulence_result is not None and context.data_config.amdar_config is not None:
-        DiagnosticsAmdarLauncher(context.data_config, context.output_dir, context.name).launch(turbulence_result.suite)
     client.close()

--- a/src/rojak/core/data.py
+++ b/src/rojak/core/data.py
@@ -495,8 +495,9 @@ class AmdarTurbulenceData(ABC):
     def _drop_manoeuvre_data_qc(self, data_frame: "dd.DataFrame") -> "dd.DataFrame":
         raise NotImplementedError("Method must be implemented by child class")
 
+    @staticmethod
     @abstractmethod
-    def turbulence_column_names(self) -> list[str]:
+    def turbulence_column_names() -> list[str]:
         raise NotImplementedError("Method must be implemented by child class")
 
     def __apply_quality_control(self, data_frame: "dd.DataFrame") -> "dd.DataFrame":

--- a/src/rojak/core/data.py
+++ b/src/rojak/core/data.py
@@ -122,7 +122,7 @@ class CATPrognosticData:
         if not set(dataset.coords.keys()).issuperset(self.required_coords):
             missing_coords = self.required_coords - dataset.coords.keys()
             raise ValueError(f"Attempting to instantiate CATPrognosticData with missing coords: {missing_coords}")
-        self._dataset = dataset.persist()
+        self._dataset = dataset.sortby("time").persist()
         blocking_wait_futures(self._dataset)
 
     def temperature(self) -> xr.DataArray:

--- a/src/rojak/datalib/madis/amdar.py
+++ b/src/rojak/datalib/madis/amdar.py
@@ -282,5 +282,6 @@ class AcarsAmdarTurbulenceData(AmdarTurbulenceData):
         # return data_frame[data_frame["rollFlag"] == ord("G")]
         return data_frame
 
-    def turbulence_column_names(self) -> list[str]:
+    @staticmethod
+    def turbulence_column_names() -> list[str]:
         return ["maxEDR", "maxTurbulence", "medEDR", "medTurbulence", "turbIndex", "vertGust"]

--- a/src/rojak/datalib/ukmo/amdar.py
+++ b/src/rojak/datalib/ukmo/amdar.py
@@ -103,5 +103,6 @@ class UkmoAmdarTurbulenceData(AmdarTurbulenceData):
         # roll_angle is NA in entire month of Jan and May in 2024
         return data_frame
 
-    def turbulence_column_names(self) -> list[str]:
+    @staticmethod
+    def turbulence_column_names() -> list[str]:
         return ["turbulence_degree"]

--- a/src/rojak/orchestrator/configuration.py
+++ b/src/rojak/orchestrator/configuration.py
@@ -15,7 +15,7 @@
 import datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Any, Self, assert_never
+from typing import TYPE_CHECKING, Annotated, Any, Self, assert_never
 
 import numpy as np
 import yaml
@@ -25,6 +25,9 @@ from rojak.datalib.madis.amdar import AcarsAmdarTurbulenceData
 from rojak.datalib.ukmo.amdar import UkmoAmdarTurbulenceData
 from rojak.turbulence.verification import DiagnosticsAmdarHarmonisationStrategyOptions
 from rojak.utilities.types import Limits
+
+if TYPE_CHECKING:
+    from rojak.core.data import AmdarTurbulenceData
 
 
 class InvalidConfigurationError(Exception):
@@ -578,7 +581,10 @@ class AmdarConfig(BaseInputDataConfig[AmdarDataSource]):
     def check_valid_diagnostic_validation_conditions(self) -> Self:
         if self.diagnostic_validation is not None:
             # Update this once there is more than two classes
-            data_source_class = UkmoAmdarTurbulenceData if self.data_source.UKMO else AcarsAmdarTurbulenceData
+            data_source_class: AmdarTurbulenceData = (
+                UkmoAmdarTurbulenceData if self.data_source == AmdarDataSource.UKMO else AcarsAmdarTurbulenceData
+            )  # pyright: ignore [reportAssignmentType]
+            print(data_source_class)
             if not {
                 condition.observed_turbulence_column_name
                 for condition in self.diagnostic_validation.validation_conditions

--- a/src/rojak/orchestrator/configuration.py
+++ b/src/rojak/orchestrator/configuration.py
@@ -542,9 +542,9 @@ class AmdarConfig(BaseInputDataConfig[AmdarDataSource]):
     ]
     # ASSUME FOR NOW ONLY USE FOR THIS IS DATA HARMONISATION
     harmonisation_strategies: Annotated[
-        list[DiagnosticsAmdarHarmonisationStrategyOptions],
-        Field(description="List of harmonisation strategies", repr=True, frozen=True),
-    ]
+        list[DiagnosticsAmdarHarmonisationStrategyOptions] | None,
+        Field(description="List of harmonisation strategies", repr=True, default=None),
+    ] = None
     save_harmonised_data: Annotated[
         bool, Field(description="Save harmonised data", repr=True, frozen=True, default=True)
     ] = True
@@ -552,6 +552,10 @@ class AmdarConfig(BaseInputDataConfig[AmdarDataSource]):
         DiagnosticValidationConfig | None,
         Field(description="Diagnostic validation configuration", repr=True, frozen=True, default=None),
     ] = None
+
+    def model_post_init(self, context: Any, /) -> None:  # noqa: ANN401
+        if self.harmonisation_strategies is None:
+            self.harmonisation_strategies = []
 
     @model_validator(mode="after")
     def check_valid_glob_pattern(self) -> Self:

--- a/src/rojak/orchestrator/turbulence.py
+++ b/src/rojak/orchestrator/turbulence.py
@@ -526,7 +526,10 @@ class DiagnosticsAmdarLauncher:
                     name: roc_result.true_positives for name, roc_result in by_diagnostic_roc.items()
                 }
                 plot_roc_curve(
-                    false_positives, true_positives, str(self._plots_dir / f"roc_{amdar_verification_col}.png")
+                    false_positives,
+                    true_positives,
+                    str(self._plots_dir / f"roc_{amdar_verification_col}.png"),
+                    area_under_curve=roc.auc_for_amdar_column(amdar_verification_col),
                 )
                 logger.debug("Created roc plot for %s AMDAR turbulence measure", amdar_verification_col)
 

--- a/src/rojak/orchestrator/turbulence.py
+++ b/src/rojak/orchestrator/turbulence.py
@@ -474,7 +474,7 @@ class DiagnosticsAmdarLauncher:
             base_dir / f"{self._data_source}_{self._time_window.lower.strftime(time_format)}"
             f"_{self._time_window.upper.strftime(time_format)}.parquet"
         )
-        self.plots_dir = plots_dir
+        self._plots_dir = plots_dir
 
     def create_amdar_data_repository(self) -> "AmdarDataRepository":
         match self._data_source:

--- a/src/rojak/orchestrator/turbulence.py
+++ b/src/rojak/orchestrator/turbulence.py
@@ -474,7 +474,8 @@ class DiagnosticsAmdarLauncher:
             base_dir / f"{self._data_source}_{self._time_window.lower.strftime(time_format)}"
             f"_{self._time_window.upper.strftime(time_format)}.parquet"
         )
-        self._plots_dir = plots_dir
+        self._plots_dir = plots_dir / run_name
+        self._plots_dir.mkdir(parents=True, exist_ok=True)
 
     def create_amdar_data_repository(self) -> "AmdarDataRepository":
         match self._data_source:

--- a/src/rojak/orchestrator/turbulence.py
+++ b/src/rojak/orchestrator/turbulence.py
@@ -528,3 +528,6 @@ class DiagnosticsAmdarLauncher:
                 plot_roc_curve(
                     false_positives, true_positives, str(self._plots_dir / f"roc_{amdar_verification_col}.png")
                 )
+                logger.debug("Created roc plot for %s AMDAR turbulence measure", amdar_verification_col)
+
+            logger.info("Finished validation of diagnostics with amdar data")

--- a/src/rojak/plot/turbulence_plotter.py
+++ b/src/rojak/plot/turbulence_plotter.py
@@ -30,6 +30,7 @@ from rojak.turbulence.analysis import Hemisphere, LatitudinalRegion
 from rojak.utilities.types import is_dask_array, is_np_array
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     import dask.array as da
@@ -358,8 +359,8 @@ def _evaluate_dask_collection(array: "da.Array | NDArray") -> "NDArray":
 
 
 def plot_roc_curve(
-    false_positive_rates: "dict[DiagnosticName, da.Array | NDArray]",
-    true_positive_rates: "dict[DiagnosticName, da.Array | NDArray]",
+    false_positive_rates: "Mapping[DiagnosticName, da.Array | NDArray]",
+    true_positive_rates: "Mapping[DiagnosticName, da.Array | NDArray]",
     plot_name: str,
 ) -> None:
     assert set(false_positive_rates.keys()) == set(true_positive_rates.keys())

--- a/src/rojak/plot/turbulence_plotter.py
+++ b/src/rojak/plot/turbulence_plotter.py
@@ -362,8 +362,11 @@ def plot_roc_curve(
     false_positive_rates: "Mapping[DiagnosticName, da.Array | NDArray]",
     true_positive_rates: "Mapping[DiagnosticName, da.Array | NDArray]",
     plot_name: str,
+    area_under_curve: "Mapping[str, float] | None" = None,
 ) -> None:
     assert set(false_positive_rates.keys()) == set(true_positive_rates.keys())
+    if area_under_curve is not None:
+        assert set(false_positive_rates.keys()).issubset(area_under_curve.keys())
     fpr: dict[DiagnosticName, NDArray] = {
         name: _evaluate_dask_collection(rate) for name, rate in false_positive_rates.items()
     }
@@ -379,7 +382,12 @@ def plot_roc_curve(
 
     fig: Figure = plt.figure(figsize=(8, 6))
     for name, colour in zip(fpr.keys(), line_colours, strict=False):
-        plt.plot(fpr[name], tpr[name], color=colour, label=name)
+        plt.plot(
+            fpr[name],
+            tpr[name],
+            color=colour,
+            label=name if area_under_curve is None else f"{name} - AUC: {area_under_curve[name]:.2f}",
+        )
     # Default line width is 1.5 according to docs
     plt.plot(np.linspace(0, 1, 500), np.linspace(0, 1, 500), color="black", linewidth=1, linestyle="--")
     plt.xlabel("False Positive Rate")

--- a/src/rojak/turbulence/diagnostic.py
+++ b/src/rojak/turbulence/diagnostic.py
@@ -1346,6 +1346,10 @@ class DiagnosticSuite:
     def diagnostic_names(self) -> list["DiagnosticName"]:
         return list(self._diagnostics.keys())
 
+    def get_prototype_computed_diagnostic(self) -> xr.DataArray:
+        _, prototype = next(self.computed_values(""))
+        return prototype
+
 
 class CalibrationDiagnosticSuite(DiagnosticSuite):
     def __init__(self, factory: DiagnosticFactory, diagnostics: list[TurbulenceDiagnostics]) -> None:

--- a/src/rojak/turbulence/metrics.py
+++ b/src/rojak/turbulence/metrics.py
@@ -110,7 +110,7 @@ def received_operating_characteristic(
     )
 
 
-def check_lazy_sizes_equal[T: xr.DataArray | da.Array](first_array: T, second_array: T) -> int:
+def _check_lazy_sizes_equal[T: xr.DataArray | da.Array](first_array: T, second_array: T) -> int:
     assert is_dask_collection(first_array)
     assert is_dask_collection(second_array)
     sizes = dask.compute(first_array.size, second_array.size)  # pyright: ignore[reportPrivateImportUsage]
@@ -180,7 +180,7 @@ def binary_classification_curve(
     """
     if sorted_truth.ndim != 1 or sorted_values.ndim != 1:
         raise ValueError("sorted_truth and sorted_values must be 1D")
-    check_lazy_sizes_equal(sorted_truth, sorted_values)
+    _check_lazy_sizes_equal(sorted_truth, sorted_values)
 
     if sorted_truth.dtype != bool:
         if positive_classification_label is None:
@@ -244,7 +244,7 @@ def _parallel_area_under_curve(x_values: da.Array | xr.DataArray, y_values: da.A
         assert is_dask_array(y_values)
         y_vals: da.Array = y_values
 
-    array_size = check_lazy_sizes_equal(x_vals, y_vals)
+    array_size = _check_lazy_sizes_equal(x_vals, y_vals)
     if array_size < 2:  # noqa: PLR2004
         raise ValueError("x_value and y_values must have at least 2 points to compute area under the curve")
 

--- a/src/rojak/turbulence/metrics.py
+++ b/src/rojak/turbulence/metrics.py
@@ -194,9 +194,12 @@ def binary_classification_curve(
         raise ValueError("values must be strictly decreasing")
     diff_values = da.abs(diff_values)
 
-    values_min: float = da.nanmin(sorted_values).compute()
-    values_max: float = da.nanmax(sorted_values).compute()
-    minimum_step_size: float = np.abs(values_max - values_min) / num_intervals
+    if num_intervals == -1:
+        minimum_step_size: float = 0.0
+    else:
+        values_min: float = da.nanmin(sorted_values).compute()
+        values_max: float = da.nanmax(sorted_values).compute()
+        minimum_step_size: float = np.abs(values_max - values_min) / num_intervals
 
     # As the values would be from the turbulence diagnostics, they are continuous
     # To reduce the data, use step_size to determine the minimum difference between two data points

--- a/src/rojak/turbulence/verification.py
+++ b/src/rojak/turbulence/verification.py
@@ -555,6 +555,7 @@ class DiagnosticsAmdarVerification:
                 result[amdar_turbulence_col][diagnostic_val_col] = received_operating_characteristic(
                     subset_df[amdar_turbulence_col].values.compute_chunk_sizes(),  # noqa: PD011
                     subset_df[diagnostic_val_col].values.compute_chunk_sizes(),  # noqa: PD011
+                    num_intervals=-1,
                 )
         logger.debug("Finished computing ROC curves")
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -15,6 +15,7 @@ from rojak.orchestrator.configuration import (
     AmdarConfig,
     AmdarDataSource,
     DataConfig,
+    DiagnosticsAmdarHarmonisationStrategyOptions,
     DiagnosticValidationCondition,
     DiagnosticValidationConfig,
     InvalidConfigurationError,
@@ -23,7 +24,6 @@ from rojak.orchestrator.configuration import (
     TurbulenceThresholdMode,
     TurbulenceThresholds,
 )
-from rojak.turbulence.verification import DiagnosticsAmdarHarmonisationStrategyOptions
 from rojak.utilities.types import Limits
 
 if TYPE_CHECKING:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -15,6 +15,8 @@ from rojak.orchestrator.configuration import (
     AmdarConfig,
     AmdarDataSource,
     DataConfig,
+    DiagnosticValidationCondition,
+    DiagnosticValidationConfig,
     InvalidConfigurationError,
     SpatialDomain,
     TurbulenceSeverity,
@@ -592,6 +594,64 @@ def test_amdar_config(
         assert config.data_source == amdar_type
         assert config.glob_pattern == glob_pattern
         assert config.data_dir == tmp_path
+
+    if e != 0:
+        assert e.type is InvalidConfigurationError
+
+
+@pytest.mark.parametrize(
+    ("conditions", "data_source", "expectation"),
+    [
+        (
+            [DiagnosticValidationCondition(observed_turbulence_column_name="turbulence_degree", value_greater_than=0)],
+            AmdarDataSource.UKMO,
+            nullcontext(0),
+        ),
+        (
+            [DiagnosticValidationCondition(observed_turbulence_column_name="rando_name", value_greater_than=0)],
+            AmdarDataSource.UKMO,
+            pytest.raises(InvalidConfigurationError),
+        ),
+        (
+            [DiagnosticValidationCondition(observed_turbulence_column_name="maxEDR", value_greater_than=0)],
+            AmdarDataSource.MADIS,
+            nullcontext(0),
+        ),
+        (
+            [DiagnosticValidationCondition(observed_turbulence_column_name="maxEdr", value_greater_than=0)],
+            AmdarDataSource.MADIS,
+            pytest.raises(InvalidConfigurationError),
+        ),
+        (
+            [
+                DiagnosticValidationCondition(observed_turbulence_column_name="maxEDR", value_greater_than=0),
+                DiagnosticValidationCondition(observed_turbulence_column_name="maxTurbulence", value_greater_than=0),
+                DiagnosticValidationCondition(observed_turbulence_column_name="medEDR", value_greater_than=0),
+                DiagnosticValidationCondition(observed_turbulence_column_name="medTurbulence", value_greater_than=0),
+                DiagnosticValidationCondition(observed_turbulence_column_name="turbIndex", value_greater_than=0),
+                DiagnosticValidationCondition(observed_turbulence_column_name="vertGust", value_greater_than=0),
+            ],
+            AmdarDataSource.MADIS,
+            nullcontext(0),
+        ),
+    ],
+)
+def test_check_valid_diagnostic_conditions(
+    tmp_path: "Path", conditions: list[DiagnosticValidationCondition], data_source: AmdarDataSource, expectation
+) -> None:
+    with expectation as e:
+        print(data_source)
+        config = AmdarConfig(
+            data_dir=tmp_path,
+            data_source=data_source,
+            glob_pattern="*.parquet" if data_source == AmdarDataSource.MADIS else "*.csv",
+            time_window=Limits(datetime(1970, 1, 1), datetime(1980, 1, 1)),
+            harmonisation_strategies=[],
+            diagnostic_validation=DiagnosticValidationConfig(validation_conditions=conditions),
+        )
+
+        assert config.diagnostic_validation is not None
+        assert config.diagnostic_validation.validation_conditions == conditions
 
     if e != 0:
         assert e.type is InvalidConfigurationError

--- a/tests/test_turbulence_mediators.py
+++ b/tests/test_turbulence_mediators.py
@@ -4,12 +4,15 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from rojak.orchestrator.configuration import TurbulenceDiagnostics, TurbulenceSeverity
+from rojak.orchestrator.configuration import (
+    DiagnosticsAmdarHarmonisationStrategyOptions,
+    TurbulenceDiagnostics,
+    TurbulenceSeverity,
+)
 from rojak.turbulence.verification import (
     DiagnosticsAmdarDataHarmoniser,
     DiagnosticsAmdarHarmonisationStrategy,
     DiagnosticsAmdarHarmonisationStrategyFactory,
-    DiagnosticsAmdarHarmonisationStrategyOptions,
     DiagnosticsSeveritiesStrategy,
     EdrSeveritiesStrategy,
     NotWithinTimeFrameError,

--- a/tests/test_turbulence_mediators.py
+++ b/tests/test_turbulence_mediators.py
@@ -4,11 +4,13 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from rojak.core.data import AmdarTurbulenceData
 from rojak.orchestrator.configuration import (
     DiagnosticsAmdarHarmonisationStrategyOptions,
     TurbulenceDiagnostics,
     TurbulenceSeverity,
 )
+from rojak.turbulence.diagnostic import DiagnosticSuite, EvaluationDiagnosticSuite
 from rojak.turbulence.verification import (
     DiagnosticsAmdarDataHarmoniser,
     DiagnosticsAmdarHarmonisationStrategy,
@@ -35,10 +37,10 @@ if TYPE_CHECKING:
 def test_diagnostic_amdar_data_harmoniser_execute_harmonisation_fail_time_window(
     mocker: "MockerFixture", make_dummy_cat_data, time_window: Limits
 ) -> None:
-    amdar_data_mock = mocker.Mock()
-    suite_mock = mocker.Mock()
+    amdar_data_mock = mocker.Mock(spec=AmdarTurbulenceData)
+    suite_mock = mocker.Mock(spec=DiagnosticSuite)
     computed_vals_mock = mocker.patch.object(
-        suite_mock, "computed_values_as_dict", return_value={"unused_key": make_dummy_cat_data({})}
+        suite_mock, "get_prototype_computed_diagnostic", return_value=make_dummy_cat_data({})
     )
 
     harmoniser = DiagnosticsAmdarDataHarmoniser(amdar_data_mock, suite_mock)
@@ -106,7 +108,7 @@ def test_diagnostic_amdar_data_harmoniser_execute_harmonisation_fail_time_window
 def test_diagnostic_amdar_harmonisation_strategy_factory_get_met_values(
     mocker: "MockerFixture", method_to_mock: str, option: DiagnosticsAmdarHarmonisationStrategyOptions
 ) -> None:
-    suite_mock = mocker.Mock()
+    suite_mock = mocker.Mock(spec=EvaluationDiagnosticSuite)
     return_val: dict = {
         "stallion-boat-tingly": xr.DataArray(
             data=generate_array_data((10, 10), True), coords={"dim0": np.arange(10), "dim1": np.arange(10)}
@@ -158,7 +160,7 @@ def test_diagnostic_amdar_harmonisation_strategy_factory_create_strategies_value
 def test_diagnostic_amdar_harmonisation_strategy_factory_create_strategies_non_values_trivial(
     mocker: "MockerFixture", method_to_mock: str, option: DiagnosticsAmdarHarmonisationStrategyOptions
 ) -> None:
-    suite_mock = mocker.Mock()
+    suite_mock = mocker.Mock(spec=EvaluationDiagnosticSuite)
     factory = DiagnosticsAmdarHarmonisationStrategyFactory(suite_mock)
     get_met_mock = mocker.patch.object(factory, "get_met_values", return_value={"key": "value"})
     method_mock = mocker.patch.object(suite_mock, method_to_mock, return_value={})
@@ -204,7 +206,7 @@ def test_diagnostic_amdar_harmonisation_strategy_factory_create_strategies_non_v
     option: DiagnosticsAmdarHarmonisationStrategyOptions,
     child_strategy_class: type,
 ) -> None:
-    suite_mock = mocker.Mock()
+    suite_mock = mocker.Mock(spec=EvaluationDiagnosticSuite)
     factory = DiagnosticsAmdarHarmonisationStrategyFactory(suite_mock)
     get_met_mock = mocker.patch.object(factory, "get_met_values", return_value={"key": "value"})
 


### PR DESCRIPTION
## Description

The library functionality to verify diagnostics against AMDAR data was implemented in #35 and #36. This PR is the plumbing needed for the CLI to invoke this functionality and to generate a plot from these calculations. It is the orchestration required to perform the validation. 

As the computing of ROC curves could be used for either the evaluation of diagnostics or at the calibration stage (e.g. to determine the thresholds and weights like the GTG), the orchestration of the turbulence analysis in the `TurbulenceLauncher` has been reworked. The plumbing for computing the ROC curves from the calibration data has yet to do be implemented. 

As this is somewhat independent on how the data is harmonised (due to how the classes have been implemented), the configuration in `AmdarConfig` has been modified to allow for no harmonisation strategies to be defined. 

An aspect that requires user input when computing the ROC curves is in determining whether turbulence has been observed. This is controlled through the `DiagnosticValidationCondition` class which specifies which column in the AMDAR data should be used for determining whether turbulence has been observed and what the value is must be greater than. 