### PR TITLE
fix: Add fallback version to hatch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ packages = ["src/rojak"]
 
 [tool.hatch.version]
 source = "vcs"
+fallback-version = "99999"
 
 [tool.coverage.report]
 exclude_also = [


### PR DESCRIPTION
When the `.git/` folder is not present, hatch is unable to figure out what the version as no VCS is present. This causes `uv sync --all-groups` to fail with, 

```console
(rojak-leaf) whl@contrails ~/rojak-leaf> uv sync --all-groups
Using CPython 3.12.3 interpreter at: /usr/bin/python3.12
Removed virtual environment at: .venv
Creating virtual environment at: .venv
Resolved 170 packages in 1ms
  × Failed to build `rojak-cat @ file:///home/whl/rojak-leaf`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
        File "/home/whl/.cache/uv/builds-v0/.tmp5IS181/lib/python3.12/site-packages/hatchling/build.py", line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory, versions=['editable'])))
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/whl/.cache/uv/builds-v0/.tmp5IS181/lib/python3.12/site-packages/hatchling/builders/plugin/interface.py", line 90, in build
          self.metadata.validate_fields()
        File "/home/whl/.cache/uv/builds-v0/.tmp5IS181/lib/python3.12/site-packages/hatchling/metadata/core.py", line 265, in validate_fields
          _ = self.version
              ^^^^^^^^^^^^
        File "/home/whl/.cache/uv/builds-v0/.tmp5IS181/lib/python3.12/site-packages/hatchling/metadata/core.py", line 149, in version
          self._version = self._get_version()
                          ^^^^^^^^^^^^^^^^^^^
        File "/home/whl/.cache/uv/builds-v0/.tmp5IS181/lib/python3.12/site-packages/hatchling/metadata/core.py", line 248, in _get_version
          version = self.hatch.version.cached
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/whl/.cache/uv/builds-v0/.tmp5IS181/lib/python3.12/site-packages/hatchling/metadata/core.py", line 1456, in cached
          raise type(e)(message) from None
      LookupError: Error getting the version from source `vcs`: setuptools-scm was unable to detect version for /home/whl/rojak-leaf.

      Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git
      checkout without the .git folder) don't contain the necessary metadata and will not work.

      For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj

      Alternatively, set the version with the environment variable SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME} as described in
      https://setuptools-scm.readthedocs.io/en/latest/config.

      hint: This usually indicates a problem with the package or the build environment.
```

By providing a fallback version, hatch can use that when the vcs is not detected. See [hatch-vcs readme docs](https://github.com/ofek/hatch-vcs?tab=readme-ov-file#version-source) for details on the options. 