### PR TITLE
fix: Condition spuriously fails on HPC. Data already in decreasing so this should never fail

### DIFF
--- a/src/rojak/turbulence/metrics.py
+++ b/src/rojak/turbulence/metrics.py
@@ -198,7 +198,7 @@ def binary_classification_curve(
         sorted_truth = sorted_truth == positive_classification_label
 
     diff_values: da.Array = da.diff(sorted_values)
-    if not da.all(diff_values <= 0).compute():
+    if da.any(diff_values > 0).compute():
         raise ValueError("values must be strictly decreasing")
     diff_values = da.abs(diff_values)
 


### PR DESCRIPTION
On the HPC, this condition will fail on one specific configuration. As I'm not able to replicate the HPC set up locally, I've not been able to test it. However, I chanced upon a situation where this was replicated and found that for that case, flipping the condition fixed the issue.